### PR TITLE
Add setComment to all PUT/POST requests

### DIFF
--- a/Atomx/AtomxClient.php
+++ b/Atomx/AtomxClient.php
@@ -127,4 +127,13 @@ class AtomxClient extends ApiClient {
 
         return $model->get();
     }
+
+    /*
+     * Sets a comment for all PUT and POST requests.
+     * These comments can will be stored in the history.
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+    }
 }


### PR DESCRIPTION
Add the ability to add a comment to every POST and PUT request. These comments can be found in the history.